### PR TITLE
Add filtering and filling capability to MappingFile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter:5.8.2')
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.8.2')
     testImplementation('org.powermock:powermock-core:2.0.9')
+    testImplementation 'com.google.jimfs:jimfs:1.1'
     compileOnly('com.google.code.findbugs:jsr305:3.0.2')
 }
 

--- a/src/main/java/net/minecraftforge/srgutils/CompleteRenamer.java
+++ b/src/main/java/net/minecraftforge/srgutils/CompleteRenamer.java
@@ -1,0 +1,73 @@
+/*
+ * SRG Utils
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.srgutils;
+
+import net.minecraftforge.srgutils.IMappingFile.IClass;
+import net.minecraftforge.srgutils.IMappingFile.IField;
+import net.minecraftforge.srgutils.IMappingFile.IMethod;
+import net.minecraftforge.srgutils.IMappingFile.IPackage;
+import net.minecraftforge.srgutils.IMappingFile.IParameter;
+
+/**
+ * Implementation of {@link IRenamer} used to rename all types of nodes in mapping
+ */
+public class CompleteRenamer implements IRenamer
+{
+
+    public CompleteRenamer(IMappingFile reference) {
+        this.reference = reference;
+    }
+
+    private final IMappingFile reference;
+
+    @Override
+    public String rename(IPackage value) {
+        IPackage pkg = reference.getPackage(value.getOriginal());
+        return pkg == null ? value.getMapped() : pkg.getMapped();
+    }
+
+    @Override
+    public String rename(IClass value) {
+        IClass cls = reference.getClass(value.getOriginal());
+        return cls == null ? value.getMapped() : cls.getMapped();
+    }
+
+    @Override
+    public String rename(IField value) {
+        IClass cls = reference.getClass(value.getParent().getOriginal());
+        IField fld = cls == null ? null : cls.getField(value.getOriginal());
+        return fld == null ? value.getMapped() : fld.getMapped();
+    }
+
+    @Override
+    public String rename(IMethod value) {
+        IClass cls = reference.getClass(value.getParent().getOriginal());
+        IMethod mtd = cls == null ? null : cls.getMethod(value.getOriginal(), value.getDescriptor());
+        return mtd == null ? value.getMapped() : mtd.getMapped();
+    }
+
+    @Override
+    public String rename(IParameter value) {
+        IMethod mtd = value.getParent();
+        IClass cls = reference.getClass(mtd.getParent().getOriginal());
+        mtd = cls == null ? null : cls.getMethod(mtd.getOriginal(), mtd.getDescriptor());
+        return mtd == null ? value.getMapped() : mtd.remapParameter(value.getIndex(), value.getMapped());
+    }
+}

--- a/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
@@ -96,6 +96,15 @@ public interface IMappingFile {
     void write(Path path, Format format, boolean reversed) throws IOException;
 
     IMappingFile reverse();
+
+    /**
+     * Filters mapping nodes that has equal original and mapped name.
+     * 
+     * <p>Classes and methods are removed only if children nodes can be filtered too.
+     * 
+     * @return filtered mapping without nodes with equal names
+     */
+    IMappingFile filter();
     IMappingFile rename(IRenamer renamer);
     IMappingFile chain(IMappingFile other);
 
@@ -119,6 +128,13 @@ public interface IMappingFile {
          *     "end_line": The source line for the end of this method
          */
         Map<String, String> getMetadata();
+
+        /**
+         * Determines if node can be filtered from mapping.
+         * 
+         * @return {@code true} when node can be filtered
+         */
+        boolean canBeFiltered();
     }
 
     public interface IPackage extends INode {}

--- a/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/IMappingFile.java
@@ -108,6 +108,16 @@ public interface IMappingFile {
     IMappingFile rename(IRenamer renamer);
     IMappingFile chain(IMappingFile other);
 
+    /**
+     * Fills mapping with nodes from another mapping.
+     * 
+     * <p>Both mapping must have common original side to resolve node linkage.
+     * 
+     * @param other mapping to fill with nodes
+     * @return mapping filled with missing nodes
+     */
+    IMappingFile fill(IMappingFile other);
+
     public interface INode {
         String getOriginal();
         String getMapped();

--- a/src/main/java/net/minecraftforge/srgutils/MappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/MappingFile.java
@@ -254,6 +254,40 @@ class MappingFile implements IMappingFile {
         });
     }
 
+    @Override
+    public MappingFile fill(final IMappingFile link) {
+        link.getPackages().stream().forEach(pkg -> addPackage(pkg.getOriginal(), pkg.getMapped(), pkg.getMetadata()));
+        link.getClasses().stream().forEach(cls -> {
+            Cls c;
+            if (MappingFile.this.getClass(cls.getOriginal()) == null) {
+                c = addClass(cls.getOriginal(), cls.getMapped(), cls.getMetadata());
+            } else {
+                c = MappingFile.this.getClass(cls.getOriginal());
+            }
+            cls.getFields().stream().forEach(fld -> {
+                if (c.getField(fld.getOriginal()) == null) {
+                    c.addField(fld.getOriginal(), fld.getMapped(), fld.getDescriptor(), fld.getMetadata());
+                }
+            });
+            cls.getMethods().stream().forEach(mtd -> {
+                Cls.Method m;
+                if (c.getMethod(mtd.getOriginal(), mtd.getDescriptor()) == null) {
+                    m = c.addMethod(mtd.getOriginal(), mtd.getDescriptor(), mtd.getMapped(), mtd.getMetadata());
+                } else {
+                    m = (Cls.Method)c.getMethod(mtd.getOriginal(), mtd.getDescriptor());
+                }
+                mtd.getParameters().stream().forEach(par -> {
+                    if (m.getParameters().stream().noneMatch(p -> {
+                        return p.getIndex() == par.getIndex();
+                    })) {
+                        m.addParameter(par.getIndex(), par.getOriginal(), par.getMapped(), par.getMetadata());
+                    }
+                });
+            });
+        });
+        return this;
+    }
+
     abstract class Node implements INode {
         private final String original;
         private final String mapped;

--- a/src/main/java/net/minecraftforge/srgutils/MappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/MappingFile.java
@@ -322,7 +322,7 @@ class MappingFile implements IMappingFile {
 
         @Override
         public boolean canBeFiltered() {
-            return getOriginal() == getMapped();
+            return getOriginal().equals(getMapped());
         }
 
         @Override
@@ -367,9 +367,10 @@ class MappingFile implements IMappingFile {
 
         @Override
         public boolean canBeFiltered() {
-            return getOriginal() == getMapped() && (this.fields.isEmpty() && this.methods.isEmpty()
-                || this.fieldsView.stream().allMatch(f -> f.canBeFiltered())
-                    && this.methodsView.stream().allMatch(m -> m.canBeFiltered()));
+            boolean result = getOriginal().equals(getMapped())
+                && (this.fields.isEmpty() || this.fieldsView.stream().allMatch(f -> f.canBeFiltered()))
+                && (this.methods.isEmpty() || this.methodsView.stream().allMatch(m -> m.canBeFiltered()));
+            return result;
         }
 
         @Override
@@ -457,7 +458,7 @@ class MappingFile implements IMappingFile {
 
             @Override
             public boolean canBeFiltered() {
-                return getOriginal() == getMapped();
+                return getOriginal().equals(getMapped());
             }
 
             @Override
@@ -533,8 +534,8 @@ class MappingFile implements IMappingFile {
 
             @Override
             public boolean canBeFiltered() {
-                return getOriginal() == getMapped() && this.paramsView.isEmpty()
-                    || this.paramsView.stream().allMatch(m -> m.canBeFiltered());
+                return getOriginal().equals(getMapped())
+                    && (this.paramsView.isEmpty() || this.paramsView.stream().allMatch(p -> p.canBeFiltered()));
             }
 
             @Override
@@ -588,7 +589,7 @@ class MappingFile implements IMappingFile {
                 }
                 @Override
                 public boolean canBeFiltered() {
-                    return getOriginal() == getMapped();
+                    return getOriginal().equals(getMapped());
                 }
                 @Override
                 public String write(Format format, boolean reversed) {

--- a/src/main/java/net/minecraftforge/srgutils/MappingFile.java
+++ b/src/main/java/net/minecraftforge/srgutils/MappingFile.java
@@ -195,6 +195,21 @@ class MappingFile implements IMappingFile {
     }
 
     @Override
+    public MappingFile filter() {
+        MappingFile ret = new MappingFile();
+        getPackages().stream().filter(p -> !p.canBeFiltered()).forEach(pkg -> ret.addPackage(pkg.getOriginal(), pkg.getMapped(), pkg.getMetadata()));
+        getClasses().stream().filter(c -> !c.canBeFiltered()).forEach(cls -> {
+            Cls c = ret.addClass(cls.getOriginal(), cls.getMapped(), cls.getMetadata());
+            cls.getFields().stream().filter(f -> !f.canBeFiltered()).forEach(fld -> c.addField(fld.getOriginal(), fld.getMapped(), fld.getMappedDescriptor(), fld.getMetadata()));
+            cls.getMethods().stream().filter(m -> !m.canBeFiltered()).forEach(mtd -> {
+                Cls.Method m = c.addMethod(mtd.getOriginal(), mtd.getDescriptor(), mtd.getMapped(), mtd.getMetadata());
+                mtd.getParameters().stream().filter(p -> !p.canBeFiltered()).forEach(par -> m.addParameter(par.getIndex(), par.getOriginal(), par.getMapped(), par.getMetadata()));
+            });
+        });
+        return ret;
+    }
+
+    @Override
     public MappingFile rename(IRenamer renamer) {
         MappingFile ret = new MappingFile();
         getPackages().stream().forEach(pkg -> ret.addPackage(pkg.getOriginal(), renamer.rename(pkg), pkg.getMetadata()));
@@ -272,6 +287,11 @@ class MappingFile implements IMappingFile {
         }
 
         @Override
+        public boolean canBeFiltered() {
+            return getOriginal() == getMapped();
+        }
+
+        @Override
         @Nullable
         public String write(Format format, boolean reversed) {
             String sorig = getOriginal().isEmpty() ? "." : getOriginal();
@@ -309,6 +329,13 @@ class MappingFile implements IMappingFile {
 
         protected Cls(String original, String mapped, Map<String, String> metadata) {
             super(original, mapped, metadata);
+        }
+
+        @Override
+        public boolean canBeFiltered() {
+            return getOriginal() == getMapped() && (this.fields.isEmpty() && this.methods.isEmpty()
+                || this.fieldsView.stream().allMatch(f -> f.canBeFiltered())
+                    && this.methodsView.stream().allMatch(m -> m.canBeFiltered()));
         }
 
         @Override
@@ -395,6 +422,11 @@ class MappingFile implements IMappingFile {
             }
 
             @Override
+            public boolean canBeFiltered() {
+                return getOriginal() == getMapped();
+            }
+
+            @Override
             @Nullable
             public String write(Format format, boolean reversed) {
                 if (format != Format.TSRG2 && format.hasFieldTypes() && this.desc == null)
@@ -466,6 +498,12 @@ class MappingFile implements IMappingFile {
             }
 
             @Override
+            public boolean canBeFiltered() {
+                return getOriginal() == getMapped() && this.paramsView.isEmpty()
+                    || this.paramsView.stream().allMatch(m -> m.canBeFiltered());
+            }
+
+            @Override
             public String write(Format format, boolean reversed) {
                 String oName = !reversed ? getOriginal() : getMapped();
                 String mName = !reversed ? getMapped() : getOriginal();
@@ -513,6 +551,10 @@ class MappingFile implements IMappingFile {
                 @Override
                 public int getIndex() {
                     return this.index;
+                }
+                @Override
+                public boolean canBeFiltered() {
+                    return getOriginal() == getMapped();
                 }
                 @Override
                 public String write(Format format, boolean reversed) {

--- a/src/test/java/net/minecraftforge/srgutils/test/OperationsTest.java
+++ b/src/test/java/net/minecraftforge/srgutils/test/OperationsTest.java
@@ -1,0 +1,90 @@
+/*
+ * SRG Utils
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.srgutils.test;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import net.minecraftforge.srgutils.CompleteRenamer;
+import net.minecraftforge.srgutils.IMappingFile;
+import net.minecraftforge.srgutils.IMappingFile.Format;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OperationsTest
+{
+
+    Path root = getRoot().resolve("Operations/");
+    IMappingFile srgA, srgB;
+    static FileSystem imfs = Jimfs.newFileSystem(Configuration.unix());
+
+    private Path getRoot() {
+        URL url = this.getClass().getResource("/test.marker");
+        Assertions.assertNotNull(url, "Could not find test.marker");
+        try {
+            return new File(url.toURI()).getParentFile().toPath();
+        } catch (URISyntaxException e) {
+            return new File(url.getPath()).getParentFile().toPath();
+        }
+    }
+
+    @BeforeEach
+    public void init() throws IOException {
+        this.srgA = IMappingFile.load(Files.newInputStream(root.resolve("input/A.txt")));
+        this.srgB = IMappingFile.load(Files.newInputStream(root.resolve("input/B.txt")));
+    }
+
+    @Test
+    public void testRename() throws IOException {
+        test(srgA.rename(new CompleteRenamer(srgB)), imfs.getPath("./out.txt"), Format.TSRG2, root.resolve("pattern/rename.txt"));
+    }
+
+    @Test
+    public void testFill() throws IOException {
+        test(srgA.fill(srgB), imfs.getPath("./out.txt"), Format.TSRG2, root.resolve("pattern/fill.txt"));
+    }
+
+    @AfterAll
+    public static void exit() throws IOException {
+        imfs.close();
+    }
+
+    private void test(IMappingFile result, Path dest, Format format, Path pattern) throws IOException {
+        result.write(dest, format, false);
+        Assertions.assertEquals(getFileContents(pattern), getFileContents(dest), "Pattern differ: " + pattern.getFileName());
+    }
+
+    private String getFileContents(Path file) {
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read " + file.toAbsolutePath(), e);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/srgutils/test/OperationsTest.java
+++ b/src/test/java/net/minecraftforge/srgutils/test/OperationsTest.java
@@ -77,7 +77,8 @@ public class OperationsTest
 
     private void test(IMappingFile result, Path dest, Format format, Path pattern) throws IOException {
         result.write(dest, format, false);
-        Assertions.assertEquals(getFileContents(pattern), getFileContents(dest), "Pattern differ: " + pattern.getFileName());
+        String pcontent = getFileContents(pattern).replaceAll("\r", ""); // MappingFile writes LF endings
+        Assertions.assertEquals(pcontent, getFileContents(dest), "Pattern differ: " + pattern.getFileName());
     }
 
     private String getFileContents(Path file) {

--- a/src/test/resources/Operations/input/A.txt
+++ b/src/test/resources/Operations/input/A.txt
@@ -1,0 +1,12 @@
+tsrg2 shared mappedA
+cls classA
+	fld fieldA
+	fld2 field2A
+	mtd (Lcls;ZZ)I methodA
+		1 leftA1 parameterA
+		3 leftA3 onlyA3
+		4 leftA4 onlyA4
+	mtd2 (II)D method2A
+		1 leftA1 firstA
+		2 leftA2 secondA
+cls2 classA2

--- a/src/test/resources/Operations/input/B.txt
+++ b/src/test/resources/Operations/input/B.txt
@@ -1,0 +1,11 @@
+tsrg2 shared mappedB
+cls classB
+	fld fieldB
+	fld3 I field3B
+	mtd (Lcls;ZZ)I methodB
+		1 leftB1 parameterB
+		2 leftB2 onlyB
+	mtd3 ([DII)V method3B
+		1 leftB1 firstB
+		2 leftB2 secondB
+cls3 classB2

--- a/src/test/resources/Operations/pattern/fill.txt
+++ b/src/test/resources/Operations/pattern/fill.txt
@@ -1,0 +1,18 @@
+tsrg2 left right
+cls classA
+	fld fieldA
+	fld2 field2A
+	fld3 I field3B
+	mtd (Lcls;ZZ)I methodA
+		1 leftA1 parameterA
+		2 leftB2 onlyB
+		3 leftA3 onlyA3
+		4 leftA4 onlyA4
+	mtd2 (II)D method2A
+		1 leftA1 firstA
+		2 leftA2 secondA
+	mtd3 ([DII)V method3B
+		1 leftB1 firstB
+		2 leftB2 secondB
+cls2 classA2
+cls3 classB2

--- a/src/test/resources/Operations/pattern/rename.txt
+++ b/src/test/resources/Operations/pattern/rename.txt
@@ -1,0 +1,12 @@
+tsrg2 left right
+cls classB
+	fld fieldB
+	fld2 field2A
+	mtd (Lcls;ZZ)I methodB
+		1 leftA1 parameterB
+		3 leftA3 onlyA3
+		4 leftA4 onlyA4
+	mtd2 (II)D method2A
+		1 leftA1 firstA
+		2 leftA2 secondA
+cls2 classA2


### PR DESCRIPTION
Filtering allows to remove nodes with same original and mapped side from mapping.
Filtering checks if node can be removed from mapping without interrupting rest of mapping. Fields and parameters can be always filtered because they can't have children. For classes and methods, they are tested if all children (if present) can be filtered too.

Filling is useful especially when chaining two srgs and base mapping does not cover all of nodes from second - eg. like Bukkit and official Mojang mappings. This is due to the way the mappings are chained - iterations are only performed on the base mapping nodes.
After chaining Bukkit to Mojang it can be filled with rest of Mojang nodes. That produces full mapping to convert whole Bukkit project to official names.